### PR TITLE
Add support for point-specific colors with PointStyle.ColorFunc and FillFunc

### DIFF
--- a/plot/plots/plot_test.go
+++ b/plot/plots/plot_test.go
@@ -199,7 +199,7 @@ func TestLine(t *testing.T) {
 
 	l1 := NewLine(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	plt.Legend.Add("Sine", l1)
 	plt.Legend.Add("Cos", l1)
@@ -234,7 +234,7 @@ func TestLineYRight(t *testing.T) {
 
 	l1 := NewLine(plt, sin)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l1.Styler(func(s *plot.Style) {
 		s.Range.SetMin(10)
@@ -243,7 +243,7 @@ func TestLineYRight(t *testing.T) {
 	})
 	l2 := NewLine(plt, cos)
 	if l2 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l2.Styler(func(s *plot.Style) {
 		s.RightY = true
@@ -272,7 +272,7 @@ func TestScatter(t *testing.T) {
 
 	l1 := NewScatter(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 
 	shs := plot.ShapesValues()
@@ -298,7 +298,7 @@ func TestBubble(t *testing.T) {
 
 	l1 := NewScatter(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	imagex.Assert(t, plt.RenderImage(), "bubble.png")
 }
@@ -324,14 +324,14 @@ func TestLabels(t *testing.T) {
 
 	l1 := NewLine(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l1.Style.Point.On = plot.On
 	plt.Legend.Add("Sine", l1)
 
 	l2 := NewLabels(plt, data)
 	if l2 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l2.Style.Text.Offset.X.Dp(6)
 	l2.Style.Text.Offset.Y.Dp(-6)
@@ -352,7 +352,7 @@ func TestBar(t *testing.T) {
 
 	l1 := NewBar(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l1.Style.Line.Fill = colors.Uniform(colors.Red)
 	plt.Legend.Add("Sine", l1)
@@ -361,7 +361,7 @@ func TestBar(t *testing.T) {
 
 	l2 := NewBar(plt, cos)
 	if l2 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l2.Style.Line.Fill = colors.Uniform(colors.Blue)
 	plt.Legend.Add("Cosine", l2)
@@ -387,7 +387,7 @@ func TestBarErr(t *testing.T) {
 
 	l1 := NewBar(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l1.Style.Line.Fill = colors.Uniform(colors.Red)
 	plt.Legend.Add("Sine", l1)
@@ -414,14 +414,14 @@ func TestBarStack(t *testing.T) {
 
 	l1 := NewBar(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l1.Style.Line.Fill = colors.Uniform(colors.Red)
 	plt.Legend.Add("Sine", l1)
 
 	l2 := NewBar(plt, cos)
 	if l2 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	l2.Style.Line.Fill = colors.Uniform(colors.Blue)
 	l2.StackedOn = l1
@@ -456,13 +456,13 @@ func TestErrBar(t *testing.T) {
 
 	l1 := NewLine(plt, data)
 	if l1 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 	plt.Legend.Add("Sine", l1)
 
 	l2 := NewYErrorBars(plt, data)
 	if l2 == nil {
-		t.Error("bad data")
+		t.Fatal("bad data")
 	}
 
 	imagex.Assert(t, plt.RenderImage(), "errbar.png")

--- a/plot/plots/plot_test.go
+++ b/plot/plots/plot_test.go
@@ -204,24 +204,24 @@ func TestLine(t *testing.T) {
 	plt.Legend.Add("Sine", l1)
 	plt.Legend.Add("Cos", l1)
 
-	imagex.Assert(t, plt.RenderImage(), "line.png")
+	imagex.Assert(t, plt.RenderImage(), "line")
 
 	l1.Style.Line.Fill = colors.Uniform(colors.Yellow)
-	imagex.Assert(t, plt.RenderImage(), "line-fill.png")
+	imagex.Assert(t, plt.RenderImage(), "line-fill")
 
 	l1.Style.Line.Step = plot.PreStep
-	imagex.Assert(t, plt.RenderImage(), "line-prestep.png")
+	imagex.Assert(t, plt.RenderImage(), "line-prestep")
 
 	l1.Style.Line.Step = plot.MidStep
-	imagex.Assert(t, plt.RenderImage(), "line-midstep.png")
+	imagex.Assert(t, plt.RenderImage(), "line-midstep")
 
 	l1.Style.Line.Step = plot.PostStep
-	imagex.Assert(t, plt.RenderImage(), "line-poststep.png")
+	imagex.Assert(t, plt.RenderImage(), "line-poststep")
 
 	l1.Style.Line.Step = plot.NoStep
 	l1.Style.Line.Fill = nil
 	l1.Style.Line.NegativeX = true
-	imagex.Assert(t, plt.RenderImage(), "line-negx.png")
+	imagex.Assert(t, plt.RenderImage(), "line-negx")
 }
 
 func TestLineYRight(t *testing.T) {
@@ -255,7 +255,7 @@ func TestLineYRight(t *testing.T) {
 	plt.Legend.Add("Sine", l1)
 	plt.Legend.Add("Cos", l2)
 
-	imagex.Assert(t, plt.RenderImage(), "line-righty.png")
+	imagex.Assert(t, plt.RenderImage(), "line-righty")
 }
 
 func TestScatter(t *testing.T) {
@@ -278,7 +278,7 @@ func TestScatter(t *testing.T) {
 	shs := plot.ShapesValues()
 	for _, sh := range shs {
 		l1.Style.Point.Shape = sh
-		imagex.Assert(t, plt.RenderImage(), "scatter-"+sh.String()+".png")
+		imagex.Assert(t, plt.RenderImage(), "scatter-"+sh.String()+"")
 	}
 }
 
@@ -300,7 +300,7 @@ func TestBubble(t *testing.T) {
 	if l1 == nil {
 		t.Fatal("bad data")
 	}
-	imagex.Assert(t, plt.RenderImage(), "bubble.png")
+	imagex.Assert(t, plt.RenderImage(), "bubble")
 }
 
 func TestLabels(t *testing.T) {
@@ -336,7 +336,7 @@ func TestLabels(t *testing.T) {
 	l2.Style.Text.Offset.X.Dp(6)
 	l2.Style.Text.Offset.Y.Dp(-6)
 
-	imagex.Assert(t, plt.RenderImage(), "labels.png")
+	imagex.Assert(t, plt.RenderImage(), "labels")
 }
 
 func TestBar(t *testing.T) {
@@ -357,7 +357,7 @@ func TestBar(t *testing.T) {
 	l1.Style.Line.Fill = colors.Uniform(colors.Red)
 	plt.Legend.Add("Sine", l1)
 
-	imagex.Assert(t, plt.RenderImage(), "bar.png")
+	imagex.Assert(t, plt.RenderImage(), "bar")
 
 	l2 := NewBar(plt, cos)
 	if l2 == nil {
@@ -370,7 +370,7 @@ func TestBar(t *testing.T) {
 	l2.Style.Width.Stride = 2
 	l2.Style.Width.Offset = 2
 
-	imagex.Assert(t, plt.RenderImage(), "bar-cos.png")
+	imagex.Assert(t, plt.RenderImage(), "bar-cos")
 }
 
 func TestBarErr(t *testing.T) {
@@ -392,13 +392,13 @@ func TestBarErr(t *testing.T) {
 	l1.Style.Line.Fill = colors.Uniform(colors.Red)
 	plt.Legend.Add("Sine", l1)
 
-	imagex.Assert(t, plt.RenderImage(), "bar-err.png")
+	imagex.Assert(t, plt.RenderImage(), "bar-err")
 
 	l1.Horizontal = true
 	plt.UpdateRange()
 	plt.X.Range.Min = 0
 	plt.X.Range.Max = 100
-	imagex.Assert(t, plt.RenderImage(), "bar-err-horiz.png")
+	imagex.Assert(t, plt.RenderImage(), "bar-err-horiz")
 }
 
 func TestBarStack(t *testing.T) {
@@ -427,7 +427,7 @@ func TestBarStack(t *testing.T) {
 	l2.StackedOn = l1
 	plt.Legend.Add("Cos", l2)
 
-	imagex.Assert(t, plt.RenderImage(), "bar-stacked.png")
+	imagex.Assert(t, plt.RenderImage(), "bar-stacked")
 }
 
 func TestErrBar(t *testing.T) {
@@ -465,7 +465,7 @@ func TestErrBar(t *testing.T) {
 		t.Fatal("bad data")
 	}
 
-	imagex.Assert(t, plt.RenderImage(), "errbar.png")
+	imagex.Assert(t, plt.RenderImage(), "errbar")
 }
 
 func TestStyle(t *testing.T) {
@@ -495,7 +495,7 @@ func TestStyle(t *testing.T) {
 	plt.Legend.Add("Sine", l1) // todo: auto-add!
 	plt.Legend.Add("Cos", l1)
 
-	imagex.Assert(t, plt.RenderImage(), "style_line_point.png")
+	imagex.Assert(t, plt.RenderImage(), "style_line_point")
 
 	plt = plot.New()
 	tdy := tensor.NewFloat64FromValues(data[plot.Y].(plot.Values)...)
@@ -505,7 +505,7 @@ func TestStyle(t *testing.T) {
 	l1 = NewLine(plt, plot.Data{plot.X: tdx, plot.Y: tdy})
 	plt.Legend.Add("Sine", l1) // todo: auto-add!
 	plt.Legend.Add("Cos", l1)
-	imagex.Assert(t, plt.RenderImage(), "style_line_point_auto.png")
+	imagex.Assert(t, plt.RenderImage(), "style_line_point_auto")
 }
 
 func TestTicks(t *testing.T) {
@@ -519,7 +519,7 @@ func TestTicks(t *testing.T) {
 	plt.Legend.Add("Sine", l1)
 	plt.Legend.Add("Cos", l1)
 
-	imagex.Assert(t, plt.RenderImage(), "style_noticks.png")
+	imagex.Assert(t, plt.RenderImage(), "style_noticks")
 }
 
 // todo: move into statplot and test everything

--- a/plot/plots/plot_test.go
+++ b/plot/plots/plot_test.go
@@ -17,6 +17,7 @@ import (
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/iox/imagex"
 	"cogentcore.org/core/colors"
+	"cogentcore.org/core/colors/cam/hct"
 	"cogentcore.org/lab/plot"
 	"cogentcore.org/lab/table"
 	"cogentcore.org/lab/tensor"
@@ -301,6 +302,38 @@ func TestBubble(t *testing.T) {
 		t.Fatal("bad data")
 	}
 	imagex.Assert(t, plt.RenderImage(), "bubble")
+}
+
+func TestScatterColor(t *testing.T) {
+	data := sinDataXY()
+
+	plt := plot.New()
+	plt.Title.Text = "Test Scatter Color"
+	plt.X.Range.Min = 0
+	plt.X.Range.Max = 100
+	plt.X.Label.Text = "X Axis"
+	plt.Y.Range.Min = 0
+	plt.Y.Range.Max = 100
+	plt.Y.Label.Text = "Y Axis"
+	plt.Style.PointSize.Px(10)
+
+	l1 := NewScatter(plt, data)
+	if l1 == nil {
+		t.Fatal("bad data")
+	}
+
+	x := data[plot.X]
+	y := data[plot.Y]
+	l1.Styler(func(s *plot.Style) {
+		s.Point.ColorFunc = func(i int) image.Image {
+			xi, yi := float32(x.Float1D(i)), float32(y.Float1D(i))
+			c := hct.New(xi*3.6, yi, 50)
+			return colors.Uniform(c.AsRGBA())
+		}
+		s.Point.FillFunc = s.Point.ColorFunc
+	})
+
+	imagex.Assert(t, plt.RenderImage(), "scatter-color")
 }
 
 func TestLabels(t *testing.T) {

--- a/plot/plots/xy.go
+++ b/plot/plots/xy.go
@@ -272,6 +272,7 @@ func (ln *XY) Plot(plt *plot.Plot) {
 			if ln.Size != nil {
 				ln.Style.Point.Size.Dots *= float32(plt.SizeAxis.Norm(ln.Size.Float1D(i)))
 			}
+			ln.Style.Point.SetStrokeIndex(pc, i)
 			ln.Style.Point.DrawShape(pc, math32.Vec2(ptx, pty))
 		}
 		ln.Style.Point.Size = origSize

--- a/plot/point.go
+++ b/plot/point.go
@@ -71,7 +71,7 @@ func (ps *PointStyle) IsOn(pt *Plot) bool {
 	uc := pt.UnitContext()
 	ps.Width.ToDots(uc)
 	ps.Size.ToDots(uc)
-	if ps.On == Off || ps.Color == nil || ps.Width.Dots == 0 || ps.Size.Dots == 0 {
+	if ps.On == Off || (ps.Color == nil && ps.Fill == nil && ps.ColorFunc == nil && ps.FillFunc == nil) || ps.Width.Dots == 0 || ps.Size.Dots == 0 {
 		return false
 	}
 	return true
@@ -94,6 +94,18 @@ func (ps *PointStyle) SetStroke(pt *Plot) bool {
 		pc.Fill.Color = nil
 	}
 	return true
+}
+
+// SetStrokeIndex sets the stroke and fill colors based on index-specific
+// color functions if applicable ([PointStyle.ColorFunc] and
+// [PointStyle.FillFunc]).
+func (ps *PointStyle) SetStrokeIndex(pc *paint.Painter, i int) {
+	if ps.ColorFunc != nil {
+		pc.Stroke.Color = ps.ColorFunc(i)
+	}
+	if ps.FillFunc != nil && ps.Shape <= Pyramid {
+		pc.Fill.Color = ps.FillFunc(i)
+	}
 }
 
 // DrawShape draws the given shape

--- a/plot/point.go
+++ b/plot/point.go
@@ -22,13 +22,20 @@ type PointStyle struct { //types:add -setters
 	Shape Shapes
 
 	// Color is the stroke color image specification.
-	// Setting to nil turns line off.
+	// Setting to nil turns stroke off. See also [PointStyle.ColorFunc].
 	Color image.Image
 
-	// Fill is the color to fill solid regions, in a plot-specific
-	// way (e.g., the area below a Line plot, the bar color).
-	// Use nil to disable filling.
+	// Fill is the color to fill points.
+	// Use nil to disable filling. See also [PointStyle.FillFunc].
 	Fill image.Image
+
+	// ColorFunc, if non-nil, is used instead of [PointStyle.Color].
+	// The function returns the stroke color to use for a given point index.
+	ColorFunc func(i int) image.Image
+
+	// FillFunc, if non-nil, is used instead of [PointStyle.Fill].
+	// The function returns the fill color to use for a given point index.
+	FillFunc func(i int) image.Image
 
 	// Width is the line width for point glyphs, with a default of 1 Pt (point).
 	// Setting to 0 turns line off.


### PR DESCRIPTION
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/87d8b040-c51e-4424-8382-5c8cfd943400" />

It should be easy to add similar to support to lines and bar plots at some point.
